### PR TITLE
fix: Added pip 20.2 resolver option

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@ virtualenv -p python3 venv
 
 source venv/bin/activate
 
-pip install -r requirements.txt
+pip install --use-feature=2020-resolver -r requirements.txt
 
 git clone https://github.com/girisagar46/girisagar46.github.io-theme.git themes/girisagar46.github.io-theme
 


### PR DESCRIPTION
## why
- pip has a problem as a dependency manager without this option.

## What

- pip 20.2 includes a new resolver `--use-feature=2020-resolver` flag
- Added resolver flag to improve resolution of dependencies in `requirements.txt`

## refs
https://pip.pypa.io/en/stable/user_guide/#changes-to-the-pip-dependency-resolver-in-20-2-2020